### PR TITLE
Add Deploy to PandaStack button

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Spell whisperer is a prompt injection challenge based on Grok API (of course, yo
 By clicking the following button, you will clone a repo from here and deploy your own app on Vercel.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/CX330Blake/Spell-Whisperer)
+[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=CX330Blake/Spell-Whisperer&type=static&buildCmd=npm+run+build&outputDir=dist)
 
 ### Deploy on your own
 


### PR DESCRIPTION
<img src="https://pandastack.io/logo.png" alt="PandaStack" height="40"/>

## Add Deploy to PandaStack button

This PR adds a **[Deploy to PandaStack](https://pandastack.io)** button alongside the existing Vercel button.

**[PandaStack](https://pandastack.io)** is a cloud deployment platform — supports static sites, containerized apps, databases, cronjobs, and more. A great alternative hosting option for your users.

### What this adds
```
[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=CX330Blake/Spell-Whisperer)
```

Happy to adjust build settings or output directory if needed. Feel free to close if you'd prefer to keep one button. 🙂

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added PandaStack as an additional deployment option alongside the existing Vercel deploy button, giving users more choices for deploying their applications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CX330Blake/Spell-Whisperer/pull/40)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->